### PR TITLE
Add .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   # Our basic build job
   build:
     docker:
-      - image: "debian:stretch"
+      - image: "debian:bookworm"
     steps:
       - run:
           name: Installing SSH and git


### PR DESCRIPTION
Debian stretch is no more maintained, so upgrade to bookworm instead.