### PR TITLE
Remove dependency on backtrace header

### DIFF
--- a/lib/include/Types.hpp
+++ b/lib/include/Types.hpp
@@ -91,7 +91,6 @@
     #include <arpa/inet.h>
     #include <dirent.h>
     #include <errno.h>
-    #include <execinfo.h>
     #include <fcntl.h>
     #include <netdb.h>
     #include <netinet/in.h>


### PR DESCRIPTION
backtrace is a GNU libc extension that's not present on other libc. Since eMQTT5 doesn't include the backtrace symbol collection like the ClassPath, it is not required to include execinfo.h header.