### PR TITLE
Fix: Prevent write on un-connected socket

### DIFF
--- a/lib/src/Network/Clients/MQTTClient.cpp
+++ b/lib/src/Network/Clients/MQTTClient.cpp
@@ -1235,7 +1235,7 @@ namespace Network { namespace Client {
             int err;
             socklen_t len = sizeof(err);
             getsockopt(socket, SOL_SOCKET, SO_ERROR, &err, &len);
-            if (err != 0) return -6;
+            if (err != 0) return -8;
 
             // Restore blocking behavior here
             if (::fcntl(socket, F_SETFL, socketFlags) != 0) return -3;


### PR DESCRIPTION
On QNX7.1 (aarch64) I ran into the issue that my app is silently killed via `SIGPIPE` when trying to connect to a host which is available but has no MQTT broker running.

This is caused by `connect()` and the following `select()`  calls within `BaseSocket::connect` do not return any error resulting in a write attempt on a not-connected socket.

When also checking for any socket errors `BaseSocket::connect` will fail already preventing any further action (e.g. ssl handshake) on this unconnected socket.